### PR TITLE
Fix error loading multiple versions of json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- Fix error loading multiple versions of json
 
 ## [0.2.0] - 2017-04-18
 ### Added

--- a/bin/check-meta-ruby.rb
+++ b/bin/check-meta-ruby.rb
@@ -39,8 +39,8 @@
 #   for details.
 #
 
-require 'json'
 require 'sensu-plugin/check/cli'
+require 'json'
 
 #
 # Check Meta

--- a/sensu-plugins-meta.gemspec
+++ b/sensu-plugins-meta.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
   s.version = SensuPluginsMeta::Version::VER_STRING
 
-  s.add_runtime_dependency 'sensu-plugin', '< 3.0'
+  s.add_runtime_dependency 'sensu-plugin', '>= 1.2', '< 3.0'
 
   s.add_development_dependency 'bundler', '~> 1.7'
   s.add_development_dependency 'coveralls', '~> 0.8'


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

~Update README with any necessary configuration snippets~

~Binstubs are created if needed~

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

Load sensu-plugin first so it brings in whatever version of json it
depends on, preventing us from trying to load dueling versions.
