### PR TITLE
Reconfigure the CI build so it passes again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,16 +16,13 @@ addons:
 services:
   - docker
 
-install:
-  - chef exec bundle install
-
 env:
   - SUITE=unit
   - SUITE=sensu-latest
   - SUITE=sensu-029
 
 script:
-  - if test "$SUITE" = "unit"; then chef exec rake; fi
+  - if test "$SUITE" = "unit"; then bundle exec rake; fi
   - if test "$SUITE" != "unit"; then chef exec kitchen test $SUITE; fi
 
 stages:
@@ -55,5 +52,6 @@ notifications:
   slack:
     on_failure: change
     on_success: never
+    on_pull_requests: false
     rooms:
       - secure: nNDUtNj7uj58n8cauL+wkWU4Yt5ZoZETZ2ROzJ0jU8RbyQNiedTRBZ10fHch6tA9WYsvAt5GfgumAUAUJeNN62HmqXCNb6OVvjh1VVzEfN3J4jk5iYj1RXsT1kx/wnQ3z9LdsgsLFP2YyxVolE3iA+SSoYZH6NdhTmC7bgGG16fTV811RYV+bYafO5QwCtqkQIWdP1522Ja2Emd+6bV87J1RTZ3N9UGu9eSmRhSdPz+jooPhbl/dUm5RIHb7bS9qJmT6+/a52pbTOWZBJc/yorlneJCHw9XiJ5HbE9v0aQV1Rpqo6l54P2hClIKz5ajID5qce2DAjM8/H40hBzfcslly4tMnEJrylAxAM3V+QGX2LdN5ub3L95Rhzp38SGtw78t7vruya34nfnBjxFPHysmX9N+lMZsJlGwSbnNvTSeHSNgrDjjy184TsAeIjSBQZbt5FHJpWfqSSIgPX/hKaFcQP1HTxIcpVJ2+UlEdmcRRmycMHQSJJUap0Dj9y6PJ+HL9STuNn6oKqMQNSdsbH9cqXUZ/en38eLuyTfB1rwGerlqNrCcXUtJsAz2nyy/HeZ7m7SZawzzGY5UG2q07oRM1iRAYL2a//FTN++FZLG2yy2pDd8hjxDxJBTLZyc1iB//q7YrsCsp3g+jB8tLzLaNEszwLYM3f569ixgBtd1g=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
+## [0.3.4] - 2018-05-09
+### Changed
+- Reconfigure the CI build so it passes again
+
 ## [0.3.3] - 2018-03-07
 ### Changed
 - Fix a new style violation

--- a/README.md
+++ b/README.md
@@ -3,14 +3,10 @@ Sensu Plugins Meta
 
 [![Build Status](https://img.shields.io/travis/socrata-platform/sensu-plugins-meta.svg)][travis]
 [![Gem Version](https://img.shields.io/gem/v/sensu-plugins-meta.svg)][rubygems]
-[![Code Climate](https://img.shields.io/codeclimate/github/socrata-platform/sensu-plugins-meta.svg)][codeclimate]
-[![Test Coverage](https://img.shields.io/coveralls/socrata-platform/sensu-plugins-meta.svg)][coveralls]
 [![Dependency Status](https://gemnasium.com/socrata-platform/sensu-plugins-meta.svg)][gemnasium]
 
 [travis]: https://travis-ci.org/socrata-platform/sensu-plugins-meta
 [rubygems]: https://rubygems.org/gems/sensu-plugins-meta
-[codeclimate]: https://codeclimate.com/github/socrata-platform/sensu-plugins-meta
-[coveralls]: https://coveralls.io/r/socrata-platform/sensu-plugins-meta
 [gemnasium]: https://gemnasium.com/socrata-platform/sensu-plugins-meta
 
 Functionality

--- a/lib/sensu_plugins_meta/version.rb
+++ b/lib/sensu_plugins_meta/version.rb
@@ -8,7 +8,7 @@ module SensuPluginsMeta
     # The minor version.
     MINOR = 3
     # The patch version.
-    PATCH = 3
+    PATCH = 4
     # Concat them into a version string
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end

--- a/sensu-plugins-meta.gemspec
+++ b/sensu-plugins-meta.gemspec
@@ -38,12 +38,8 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'sensu-plugin', '>= 1.2', '< 3.0'
 
-  s.add_development_dependency 'berkshelf', '~> 6.3'
   s.add_development_dependency 'bundler', '~> 1.7'
-  s.add_development_dependency 'coveralls', '~> 0.8'
   s.add_development_dependency 'github-markup', '~> 2.0'
-  s.add_development_dependency 'kitchen-dokken', '~> 2.6'
-  s.add_development_dependency 'kitchen-inspec', '~> 0.22'
   s.add_development_dependency 'pry', '~> 0.10'
   s.add_development_dependency 'rake', '~> 12.0'
   s.add_development_dependency 'redcarpet', '~> 3.2'
@@ -51,6 +47,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop', '~> 0.52'
   s.add_development_dependency 'simplecov', '~> 0.12'
   s.add_development_dependency 'simplecov-console', '~> 0.4'
-  s.add_development_dependency 'test-kitchen', '~> 1.6'
   s.add_development_dependency 'yard', '~> 0.9'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,18 +3,7 @@
 require 'rspec'
 require 'simplecov'
 require 'simplecov-console'
-require 'coveralls'
 
-RSpec.configure do |c|
-  c.color = true
-end
-
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
-  [
-    Coveralls::SimpleCov::Formatter,
-    SimpleCov::Formatter::HTMLFormatter,
-    SimpleCov::Formatter::Console
-  ]
-)
+SimpleCov.formatter = SimpleCov::Formatter::Console
 SimpleCov.minimum_coverage(100)
 SimpleCov.start


### PR DESCRIPTION
Use what's packed in with Chef-dK for the integration tests and Bundler
without Test Kitchen for the unit tests. This should keep the build reasonably
fast while circumventing the "`chef exec bundle install` breaks the world"
issue.

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 