### PR TITLE
Unload gem specs before loading the desired sub-check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
+## [1.0.3] - 2019-03-29
+### Changed
+- Advertise compatibility with sensu-plugin 4.x
+- Unload gem specs before loading the desired sub-check
+
 ## [1.0.2] - 2019-02-06
 ### Changed
 - Update gem dependency pins
@@ -50,9 +55,11 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Added
 - Initial release
 
+[1.0.3]: https://github.com/socrata-platform/sensu-plugins-meta/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/socrata-platform/sensu-plugins-meta/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/socrata-platform/sensu-plugins-meta/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/socrata-platform/sensu-plugins-meta/compare/v0.3.3...v1.0.0
+[0.3.4]: https://github.com/socrata-platform/sensu-plugins-meta/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/socrata-platform/sensu-plugins-meta/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/socrata-platform/sensu-plugins-meta/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/socrata-platform/sensu-plugins-meta/compare/v0.3.0...v0.3.1

--- a/bin/check-meta-ruby.rb
+++ b/bin/check-meta-ruby.rb
@@ -38,9 +38,11 @@
 #   for details.
 #
 
-# Load the check we're going to run before doing anything else so we don't run
-# the risk of importing a version of sensu-plugin that's compatible with this
-# check but not the sub-check.
+# Unload the specs that get activated by Gem.activate_bin_path in the binstub
+# and immediately load the check we're going to run so we can get around any
+# dependency conflicts between it and this check, which is compatible with just
+# about any version of sensu-plugin or json.
+%w[sensu-plugin json mixlib-cli].each { |g| Gem.loaded_specs.delete(g) }
 idx = ARGV.index('-c') || ARGV.index('--check')
 require File.expand_path("../#{ARGV[idx + 1]}", $PROGRAM_NAME) if idx
 

--- a/lib/sensu_plugins_meta/version.rb
+++ b/lib/sensu_plugins_meta/version.rb
@@ -8,7 +8,7 @@ module SensuPluginsMeta
     # The minor version.
     MINOR = 0
     # The patch version.
-    PATCH = 2
+    PATCH = 3
     # Concat them into a version string
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end

--- a/sensu-plugins-meta.gemspec
+++ b/sensu-plugins-meta.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
   s.version = SensuPluginsMeta::Version::VER_STRING
 
-  s.add_runtime_dependency 'sensu-plugin', '>= 1.2', '< 4.0'
+  s.add_runtime_dependency 'sensu-plugin', '>= 1.2', '< 5.0'
 
   s.add_development_dependency 'bundler', '~> 2.0'
   s.add_development_dependency 'github-markup', '~> 3.0'

--- a/test/integration/default/http_cli_test.rb
+++ b/test/integration/default/http_cli_test.rb
@@ -20,6 +20,7 @@ describe command("#{check} -j '#{json}'") do
     exp = "CheckMetaRuby OK: Results: 0 critical, 0 warning, 0 unknown, 3 ok\n"
     should eq(exp)
   end
+  its(:stderr) { should be_empty }
 end
 
 # WARNING
@@ -36,6 +37,7 @@ describe command("#{check} -j '#{json}'") do
           "0 unknown, 2 ok\n"
     should eq(exp)
   end
+  its(:stderr) { should be_empty }
 end
 
 # CRITICAL
@@ -54,6 +56,7 @@ describe command("#{check} -j '#{json}'") do
           "0 unknown, 2 ok\n"
     should eq(exp)
   end
+  its(:stderr) { should be_empty }
 end
 
 # UNKNOWN
@@ -70,4 +73,5 @@ describe command("#{check} -j '#{json}'") do
           "1 unknown, 2 ok\n"
     should eq(exp)
   end
+  its(:stderr) { should be_empty }
 end

--- a/test/integration/default/http_file_test.rb
+++ b/test/integration/default/http_file_test.rb
@@ -21,6 +21,7 @@ describe command("#{check} -j /tmp/check-http-ok.json") do
     exp = "CheckMetaRuby OK: Results: 0 critical, 0 warning, 0 unknown, 3 ok\n"
     should eq(exp)
   end
+  its(:stderr) { should be_empty }
 end
 
 # WARNING
@@ -38,6 +39,7 @@ describe command("#{check} -j /tmp/check-http-warning.json") do
           "0 unknown, 2 ok\n"
     should eq(exp)
   end
+  its(:stderr) { should be_empty }
 end
 
 # CRITICAL
@@ -57,6 +59,7 @@ describe command("#{check} -j /tmp/check-http-critical.json") do
           "0 unknown, 2 ok\n"
     should eq(exp)
   end
+  its(:stderr) { should be_empty }
 end
 
 # UNKNOWN
@@ -74,4 +77,5 @@ describe command("#{check} -j /tmp/check-http-unknown.json") do
           "1 unknown, 2 ok\n"
     should eq(exp)
   end
+  its(:stderr) { should be_empty }
 end

--- a/test/integration/default/ssl_cli_test.rb
+++ b/test/integration/default/ssl_cli_test.rb
@@ -20,6 +20,7 @@ describe command("#{check} -j '#{json}'") do
     exp = "CheckMetaRuby OK: Results: 0 critical, 0 warning, 0 unknown, 3 ok\n"
     should eq(exp)
   end
+  its(:stderr) { should be_empty }
 end
 
 # WARNING
@@ -36,6 +37,7 @@ describe command("#{check} -j '#{json}'") do
                      '1 warning, 0 unknown, 2 ok\n')
     should match(exp)
   end
+  its(:stderr) { should be_empty }
 end
 
 # CRITICAL
@@ -53,6 +55,7 @@ describe command("#{check} -j '#{json}'") do
                      '1 warning, 0 unknown, 1 ok\n')
     should match(exp)
   end
+  its(:stderr) { should be_empty }
 end
 
 # UNKNOWN
@@ -70,4 +73,5 @@ describe command("#{check} -j '#{json}'") do
           "1 unknown, 3 ok\n"
     should eq(exp)
   end
+  its(:stderr) { should be_empty }
 end

--- a/test/integration/default/ssl_file_test.rb
+++ b/test/integration/default/ssl_file_test.rb
@@ -21,6 +21,7 @@ describe command("#{check} -j /tmp/check-ssl-ok.json") do
     exp = "CheckMetaRuby OK: Results: 0 critical, 0 warning, 0 unknown, 3 ok\n"
     should eq(exp)
   end
+  its(:stderr) { should be_empty }
 end
 
 # WARNING
@@ -38,6 +39,7 @@ describe command("#{check} -j /tmp/check-ssl-warning.json") do
                      '1 warning, 0 unknown, 2 ok\n')
     should match(exp)
   end
+  its(:stderr) { should be_empty }
 end
 
 # CRITICAL
@@ -56,6 +58,7 @@ describe command("#{check} -j /tmp/check-ssl-critical.json") do
                      '1 warning, 0 unknown, 1 ok\n')
     should match(exp)
   end
+  its(:stderr) { should be_empty }
 end
 
 # UNKNOWN
@@ -74,4 +77,5 @@ describe command("#{check} -j /tmp/check-ssl-unknown.json") do
           "1 unknown, 3 ok\n"
     should eq(exp)
   end
+  its(:stderr) { should be_empty }
 end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

No.

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [x] Binstubs are created if needed
- [x] RuboCop passes
- [x] Existing tests pass 

#### Purpose

The behavior of `Gem.activate_bin_path` changed starting in Ruby 2.4.5. Instead
of only loading this gem, it now loads all its deepndencies as well. This
can result in dependency conflicts when, say, this check has loaded sensu-plugin
4.0 and the sub-check hasn't yet been updated to support > 1.2.

This also bumps the sensu-plugin dep to support the recent 4.x release.